### PR TITLE
Remove FreeBSD 13.0 for aarch64.

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -21,12 +21,6 @@ packages:
           python:
           - tag: cp38
             abi: abi3
-        - platform_tag: freebsd_13_0_release_arm64
-          platform_instance: freebsd/13.0
-          platform_arch: aarch64
-          python:
-          - tag: cp38
-            abi: abi3
   cffi:
     versions:
       latest:
@@ -46,9 +40,3 @@ packages:
           platform_arch: aarch64
           python:
           - tag: cp38
-        - platform_tag: freebsd_13_0_release_arm64
-          platform_instance: freebsd/13.0
-          platform_arch: aarch64
-          python:
-          - tag: cp38
-


### PR DESCRIPTION
There is no rust toolchain available.