### PR TITLE
Unpin coverage builds.

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -53,7 +53,7 @@ packages:
           - tag: cp38
   coverage:
     versions:
-      6.3.3:
+      latest:
         wheels:
         - platform_tag: freebsd_12_3_release_amd64
           platform_instance: freebsd/12.3


### PR DESCRIPTION
This will make it easier to update coverage versions in ansible-test,
since this repository will no longer need to be kept in sync.

However, this will complicate adding new FreeBSD versions here when
the latest coverage version is not being used by ansible-test. Either
update the coverage version used there first, or temporarily add a
pinned build to match the version used.