### PR TITLE
Build `bcrypt` wheels for FreeBSD 13.1

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -3,6 +3,30 @@ packages:
     versions:
       latest:
         wheels:
+        - platform_tag: freebsd_12_2_release_amd64
+          platform_instance: freebsd/12.2
+          platform_arch: x86_64
+          python:
+          - tag: cp38
+            abi: abi3
+        - platform_tag: freebsd_12_2_release_arm64
+          platform_instance: freebsd/12.2
+          platform_arch: aarch64
+          python:
+          - tag: cp38
+            abi: abi3
+        - platform_tag: freebsd_13_0_release_amd64
+          platform_instance: freebsd/13.0
+          platform_arch: x86_64
+          python:
+          - tag: cp38
+            abi: abi3
+        - platform_tag: freebsd_13_0_release_arm64
+          platform_instance: freebsd/13.0
+          platform_arch: aarch64
+          python:
+          - tag: cp38
+            abi: abi3
         - platform_tag: freebsd_13_1_release_amd64
           platform_instance: freebsd/13.1
           platform_arch: x86_64

--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -9,12 +9,6 @@ packages:
           python:
           - tag: cp38
             abi: abi3
-        - platform_tag: freebsd_12_2_release_arm64
-          platform_instance: freebsd/12.2
-          platform_arch: aarch64
-          python:
-          - tag: cp38
-            abi: abi3
         - platform_tag: freebsd_13_0_release_amd64
           platform_instance: freebsd/13.0
           platform_arch: x86_64

--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -1,4 +1,20 @@
 packages:
+  bcrypt:
+    versions:
+      latest:
+        wheels:
+        - platform_tag: freebsd_13_1_release_amd64
+          platform_instance: freebsd/13.1
+          platform_arch: x86_64
+          python:
+          - tag: cp38
+            abi: abi3
+        - platform_tag: freebsd_13_1_release_arm64
+          platform_instance: freebsd/13.1
+          platform_arch: aarch64
+          python:
+          - tag: cp38
+            abi: abi3
   cryptography:
     versions:
       latest:

--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -15,15 +15,15 @@ packages:
           python:
           - tag: cp38
             abi: abi3
-        - platform_tag: freebsd_13_0_release_arm64
-          platform_instance: freebsd/13.0
-          platform_arch: aarch64
-          python:
-          - tag: cp38
-            abi: abi3
         - platform_tag: freebsd_13_1_release_amd64
           platform_instance: freebsd/13.1
           platform_arch: x86_64
+          python:
+          - tag: cp38
+            abi: abi3
+        - platform_tag: freebsd_13_0_release_arm64
+          platform_instance: freebsd/13.0
+          platform_arch: aarch64
           python:
           - tag: cp38
             abi: abi3


### PR DESCRIPTION
`bcrypt` now relies on `setuptools-rust` causing https://github.com/pypa/pip/issues/6264, plus it needs a Rust compiler that is unavailable in our FreeBSD VMs.
This should fix failures like https://dev.azure.com/ansible/ansible/_build/results?buildId=52061&view=logs&j=96d98051-de5a-5846-d6c0-98e63dcdbfd9&t=c2476f69-8c1f-561a-4f25-a218e506c05f&l=2635.

I'm only adding FreeBSD 13.1 to the matrix since this problem doesn't manifest itself in other VMs.