### PR TITLE
Partially revert "Build `bcrypt` wheels for FreeBSD 13.1"

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -3,27 +3,9 @@ packages:
     versions:
       latest:
         wheels:
-        - platform_tag: freebsd_12_2_release_amd64
-          platform_instance: freebsd/12.2
-          platform_arch: x86_64
-          python:
-          - tag: cp38
-            abi: abi3
-        - platform_tag: freebsd_13_0_release_amd64
-          platform_instance: freebsd/13.0
-          platform_arch: x86_64
-          python:
-          - tag: cp38
-            abi: abi3
         - platform_tag: freebsd_13_1_release_amd64
           platform_instance: freebsd/13.1
           platform_arch: x86_64
-          python:
-          - tag: cp38
-            abi: abi3
-        - platform_tag: freebsd_13_0_release_arm64
-          platform_instance: freebsd/13.0
-          platform_arch: aarch64
           python:
           - tag: cp38
             abi: abi3


### PR DESCRIPTION
Partially reverts ansible/spare-tire#9. Only keeps FreeBSD 13.1 wheels for `bcrypt`.