### PR TITLE
Revert "Build for FreeBSD 13.2 instead of 13.1. (#11)"

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -25,8 +25,8 @@ packages:
           python:
           - tag: cp38
             abi: abi3
-        - platform_tag: freebsd_13_2_release_amd64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_amd64
+          platform_instance: freebsd/13.1
           platform_arch: x86_64
           python:
           - tag: cp38
@@ -37,8 +37,8 @@ packages:
           python:
           - tag: cp38
             abi: abi3
-        - platform_tag: freebsd_13_2_release_arm64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_arm64
+          platform_instance: freebsd/13.1
           platform_arch: aarch64
           python:
           - tag: cp38
@@ -52,8 +52,8 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp38
-        - platform_tag: freebsd_13_2_release_amd64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_amd64
+          platform_instance: freebsd/13.1
           platform_arch: x86_64
           python:
           - tag: cp38
@@ -62,8 +62,8 @@ packages:
           platform_arch: aarch64
           python:
           - tag: cp38
-        - platform_tag: freebsd_13_2_release_arm64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_arm64
+          platform_instance: freebsd/13.1
           platform_arch: aarch64
           python:
           - tag: cp38
@@ -76,8 +76,8 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp38
-        - platform_tag: freebsd_13_2_release_amd64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_amd64
+          platform_instance: freebsd/13.1
           platform_arch: x86_64
           python:
           - tag: cp38
@@ -86,8 +86,8 @@ packages:
           platform_arch: aarch64
           python:
           - tag: cp38
-        - platform_tag: freebsd_13_2_release_arm64
-          platform_instance: freebsd/13.2
+        - platform_tag: freebsd_13_1_release_arm64
+          platform_instance: freebsd/13.1
           platform_arch: aarch64
           python:
           - tag: cp38


### PR DESCRIPTION
This reverts commit df7738ba33e98e905712015e08c1062f3e1f8d1b.

Premature change, since 13.2 hasn't been released yet.