### PR TITLE
Don't hard-code Python for remote instances.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,7 @@ stages:
         
         echo "##[group]run ansible-test to start $(instance),arch=$(arch) and generate build script"
         pushd collections/ansible_collections/ansible/spare_tire/
-        # FIXME don't hardcode remote Python version
-        ansible-test integration --target remote:$(instance),arch=$(arch),python=3.8 -vv wheel_builder
+        ansible-test integration --target remote:$(instance),arch=$(arch),python=$(python) -vv wheel_builder
         popd
         echo "##[endgroup]"
 

--- a/gen_build_matrix.py
+++ b/gen_build_matrix.py
@@ -62,11 +62,15 @@ class PackageBuildChecker:
         return exists
 
     @staticmethod
-    def _pytag_to_python(tag):
+    def _pytag_to_python_version(tag):
         m = re.match(r'cp(?P<maj>\d)(?P<min>\d{1,2})$', tag)
         if not m:
             raise KeyError(f'invalid python tag {tag}')
-        return f'python{m.group("maj")}.{m.group("min")}'
+        return f'{m.group("maj")}.{m.group("min")}'
+
+    @staticmethod
+    def _pytag_to_python(tag):
+        return f'python{PackageBuildChecker._pytag_to_python_version(tag)}'
 
     @property
     def build_matrix(self) -> dict:
@@ -95,6 +99,7 @@ class PackageBuildChecker:
             job_toplevel = matrix.setdefault(job_name, {})
             job_toplevel['instance'] = missing_build.platform_instance
             job_toplevel['arch'] = missing_build.platform_arch
+            job_toplevel['python'] = self._pytag_to_python_version(missing_build.python_tag),
             job_def = job_toplevel.setdefault('job_data', {})
             job_def['instance'] = missing_build.platform_instance
             job_def['arch'] = missing_build.platform_arch


### PR DESCRIPTION
Use the wheel's tagged Python version instead.