### PR TITLE
Use Python 3.9 for FreeBSD 13.2

### DIFF
--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -19,7 +19,7 @@ packages:
           platform_instance: freebsd/13.2
           platform_arch: x86_64
           python:
-          - tag: cp38
+          - tag: cp39
             abi: abi3
         - platform_tag: freebsd_12_4_release_arm64
           platform_instance: freebsd/12.4
@@ -37,7 +37,7 @@ packages:
           platform_instance: freebsd/13.2
           platform_arch: aarch64
           python:
-          - tag: cp38
+          - tag: cp39
             abi: abi3
   cryptography:
     versions:
@@ -59,7 +59,7 @@ packages:
           platform_instance: freebsd/13.2
           platform_arch: x86_64
           python:
-          - tag: cp38
+          - tag: cp39
             abi: abi3
         - platform_tag: freebsd_12_4_release_arm64
           platform_instance: freebsd/12.4
@@ -77,7 +77,7 @@ packages:
           platform_instance: freebsd/13.2
           platform_arch: aarch64
           python:
-          - tag: cp38
+          - tag: cp39
             abi: abi3
   cffi:
     versions:


### PR DESCRIPTION
Python 3.8 is not supported in ansible-test for FreeBSD 13.2.