### PR TITLE
Unpin build and update setuptools custom arg passthru

### DIFF
--- a/collections/ansible_collections/ansible/spare_tire/tests/integration/targets/wheel_builder/templates/remote_build.sh.j2
+++ b/collections/ansible_collections/ansible/spare_tire/tests/integration/targets/wheel_builder/templates/remote_build.sh.j2
@@ -20,12 +20,7 @@ mkdir -p dist
 {% for item in job_data.packages %}
 {% call do_ssh() %}
     set -eux
-    # FIXME: we have to use an old version of build until setuptools sorts out how to ignore custom args
-    # to PEP517 build hooks.
-    # see also: https://github.com/pypa/build/issues/264#issuecomment-1719316626
-    # see also: https://github.com/pypa/setuptools/issues/3896#issuecomment-1719397299
-    # see also: https://github.com/pypa/pip/issues/12273
-    {{ item.python }} -m pip install build==0.10.0
+    {{ item.python }} -m pip install build
 
     mkdir -p build_tmp
     pushd build_tmp
@@ -52,7 +47,7 @@ CONSTRAINT_EOF
 
     # FIXME do abi options better
     if [[ "{{ item.abi | default('') }}" == "abi3" ]]; then
-      ABI_ARGS='-C=--global-option=--py-limited-api -C=--global-option={{ item.python_tag }}'
+      ABI_ARGS='-C=--build-option=--py-limited-api -C=--build-option={{ item.python_tag }}'
     else
       ABI_ARGS=''
     fi

--- a/wheel_matrix.py
+++ b/wheel_matrix.py
@@ -18,7 +18,6 @@ class Package:
 
 def main() -> None:
     freebsd_pythons = {
-        '12.4': ['3.9'],
         '13.2': ['3.9', '3.11'],
     }
 

--- a/wheel_matrix.yml
+++ b/wheel_matrix.yml
@@ -4,21 +4,9 @@ packages:
     versions:
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
           python:
           - tag: cp39
             abi: abi3
@@ -32,21 +20,9 @@ packages:
     versions:
       40.0.1:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
           python:
           - tag: cp39
             abi: abi3
@@ -58,21 +34,9 @@ packages:
             abi: abi3
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
           python:
           - tag: cp39
             abi: abi3
@@ -86,11 +50,6 @@ packages:
     versions:
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -101,11 +60,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -120,11 +74,6 @@ packages:
     versions:
       7.3.2:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -135,11 +84,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -152,11 +96,6 @@ packages:
           - tag: cp311
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -167,11 +106,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -186,11 +120,6 @@ packages:
     versions:
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -201,11 +130,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -220,11 +144,6 @@ packages:
     versions:
       2.0.0:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -235,11 +154,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -252,11 +166,6 @@ packages:
           - tag: cp311
       2.1.2:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -267,11 +176,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -284,11 +188,6 @@ packages:
           - tag: cp311
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -299,11 +198,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -318,21 +212,9 @@ packages:
     versions:
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
-          python:
-          - tag: cp39
-            abi: abi3
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
           python:
           - tag: cp39
             abi: abi3
@@ -346,11 +228,6 @@ packages:
     versions:
       '6.0':
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -361,11 +238,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64
@@ -378,11 +250,6 @@ packages:
           - tag: cp311
       latest:
         wheels:
-        - platform_tag: freebsd_12_4_release_amd64
-          platform_instance: freebsd/12.4
-          platform_arch: x86_64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_amd64
           platform_instance: freebsd/13.2
           platform_arch: x86_64
@@ -393,11 +260,6 @@ packages:
           platform_arch: x86_64
           python:
           - tag: cp311
-        - platform_tag: freebsd_12_4_release_arm64
-          platform_instance: freebsd/12.4
-          platform_arch: aarch64
-          python:
-          - tag: cp39
         - platform_tag: freebsd_13_2_release_arm64
           platform_instance: freebsd/13.2
           platform_arch: aarch64


### PR DESCRIPTION
* now that setuptools and build have synced up on custom arg passthru, we can just go back to latest and switch to using `--build-option` to get custom build args like `--py-limited-api` passed through
* also drop FreeBSD 12.4 builds
